### PR TITLE
Add more DBus methods

### DIFF
--- a/herrie/configure
+++ b/herrie/configure
@@ -110,7 +110,7 @@ CONFFILE=$CONFDIR/$APP_NAME.conf
 TRANSDIR=$PREFIX/share/locale
 [ "$CC" = "" ] && CC=cc
 [ "$INSTALL" = "" ] && INSTALL=install
-MANPARTS="00-man 02-man 04-man 06-man"
+MANPARTS="00-man 02-man 04-man 06-man 10-man"
 MANREGEX="-e 's|%%CONFFILE%%|$CONFFILE|'"
 
 # Command line options
@@ -224,6 +224,7 @@ then
 	CFLAGS="$CFLAGS -DBUILD_DBUS -I."
 	SRCS="$SRCS dbus"
 	DEPENDS_EXTRA_dbus="dbus_binding.h"
+	MANPARTS="$MANPARTS 07-dbus 09-dbus"
 fi
 # GST support
 if [ "$CFG_GST" != "" ]
@@ -369,6 +370,10 @@ if [ "$CFG_VOLUME" != "" ]
 then
 	CFLAGS="$CFLAGS -DBUILD_VOLUME"
 	MANPARTS="$MANPARTS 01-volume"
+	if [ "$CFG_DBUS" != "" ]
+	then
+		MANPARTS="$MANPARTS 08-dbus-volume"
+	fi
 fi
 
 echo "Configuration:"

--- a/herrie/man/06-man
+++ b/herrie/man/06-man
@@ -22,8 +22,3 @@ as well.
 .TP
 .B vfs.lockup.user=
 Change the effective user of the application to the specified user.
-.SH AUTHORS
-.B herrie
-is maintained by Ed Schouten <ed@80386.nl>. Please visit
-.I http://herrie.info/
-for more information, documentation and developer notes.

--- a/herrie/man/07-dbus
+++ b/herrie/man/07-dbus
@@ -10,6 +10,12 @@ using bus
 info.herrie.Herrie .
 Exposed methods:
 .TP
+.B info.herrie.Herrie.next
+Skip to the next track.
+.TP
+.B info.herrie.Herrie.prev
+Play previous track in the playlist (only XMMS mode).
+.TP
 .B info.herrie.Herrie.pause
 Pause/unpause playback.
 .TP

--- a/herrie/man/07-dbus
+++ b/herrie/man/07-dbus
@@ -1,0 +1,20 @@
+.SH DBUS INTEGRATION
+.B herrie
+can be controlled from other processes using DBus IPC.
+Currently only first instance of the application can receive messages.
+DBus methods must be invoked on path
+.I
+/info/herrie/Herrie
+using bus
+.I
+info.herrie.Herrie .
+Exposed methods:
+.TP
+.B info.herrie.Herrie.pause
+Pause/unpause playback.
+.TP
+.B info.herrie.Herrie.play
+Start playback.
+.TP
+.B info.herrie.Herrie.stop
+Stop the song.

--- a/herrie/man/08-dbus-volume
+++ b/herrie/man/08-dbus-volume
@@ -1,0 +1,6 @@
+.TP
+.B info.herrie.Herrie.volumeDown
+Decrease the volume.
+.TP
+.B info.herrie.Herrie.volumeUp
+Increase the volume.

--- a/herrie/man/09-dbus
+++ b/herrie/man/09-dbus
@@ -9,7 +9,7 @@ commands to setup global hotkeys. Examples:
 .TP
 .B
 dbus-send --dest=info.herrie.Herrie /info/herrie/Herrie info.herrie.Herrie.pause
-Pause the current song.
+Pause the song.
 .TP
 .B
 dbus-send --dest=info.herrie.Herrie /info/herrie/Herrie info.herrie.Herrie.seek int32:-5

--- a/herrie/man/09-dbus
+++ b/herrie/man/09-dbus
@@ -1,0 +1,16 @@
+.TP
+.BI "info.herrie.Herrie.seek " "seconds"
+Seek song relative to current position.
+.PP
+One can bind
+.B
+dbus-send
+commands to setup global hotkeys. Examples:
+.TP
+.B
+dbus-send --dest=info.herrie.Herrie /info/herrie/Herrie info.herrie.Herrie.pause
+Pause the current song.
+.TP
+.B
+dbus-send --dest=info.herrie.Herrie /info/herrie/Herrie info.herrie.Herrie.seek int32:-5
+Seek 5 seconds backward.

--- a/herrie/man/10-man
+++ b/herrie/man/10-man
@@ -1,0 +1,5 @@
+.SH AUTHORS
+.B herrie
+is maintained by Ed Schouten <ed@80386.nl>. Please visit
+.I http://herrie.info/
+for more information, documentation and developer notes.

--- a/herrie/src/dbus.c
+++ b/herrie/src/dbus.c
@@ -107,6 +107,19 @@ dbus_server_next(DBusServer *self, GError **error)
 }
 
 /**
+ * @brief DBus event to play previous track in the playlist.
+ */
+static gboolean
+dbus_server_prev(DBusServer *self, GError **error)
+{
+	dbus_lock();
+	playq_cursong_prev();
+	dbus_unlock();
+
+	return (TRUE);
+}
+
+/**
  * @brief DBus event to pause the current track.
  */
 static gboolean

--- a/herrie/src/dbus.c
+++ b/herrie/src/dbus.c
@@ -175,6 +175,19 @@ dbus_server_volume_up(DBusServer *self, GError **error)
 	return (TRUE);
 }
 
+/**
+ * @brief DBus event to seek in the playback.
+ */
+static gboolean
+dbus_server_seek(DBusServer *self, gint32 len, GError **error)
+{
+	dbus_lock();
+	playq_cursong_seek((int) len, 1);
+	dbus_unlock();
+
+	return (TRUE);
+}
+
 #include <dbus_binding.h>
 
 /**

--- a/herrie/src/dbus.xml
+++ b/herrie/src/dbus.xml
@@ -2,6 +2,7 @@
 <node name="/info/herrie/Herrie">
 	<interface name="info.herrie.Herrie">
 		<method name="next"/>
+		<method name="prev"/>
 		<method name="pause"/>
 		<method name="play"/>
 		<method name="stop"/>

--- a/herrie/src/dbus.xml
+++ b/herrie/src/dbus.xml
@@ -7,5 +7,8 @@
 		<method name="stop"/>
 		<method name="volumeDown"/>
 		<method name="volumeUp"/>
+		<method name="seek">
+			<arg type="i"/>
+		</method>
 	</interface>
 </node>


### PR DESCRIPTION
Changes:
- seek and prev DBus methods
- DBus manpage section

I think DBus section should be added to manpages, because it is relevant not only to developers, but also to the users. I included it mostly to show examples of dbus-send command, which can be used by i3 or xbindkeys to setup global hotkeys.